### PR TITLE
Loop over kill ring

### DIFF
--- a/init.el
+++ b/init.el
@@ -356,7 +356,11 @@
           ("C-o" .  loccur-isearch)
           )))
 
+;; show clipboard history (in buffer)
 (global-set-key (kbd "M-y") 'helm-show-kill-ring)
+
+;; loop over clipboard history (in minibuffer)
+(global-set-key (kbd "C-t") 'yank-pop)
 
 ;; use helm mainly for pattern search
 (add-to-list 'load-path "~/.emacs.d/helm")


### PR DESCRIPTION
Providing two different ways to show kill ring history either by listing it in a buffer, or by looping over it in minibuffer.